### PR TITLE
Add a .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.pm]
+indent_style = tab
+tab_width = 4


### PR DESCRIPTION
This file hints to text editors that tabs should be used instead of spaces for indentation.  See https://editorconfig.org/ for more info.

I have guessed that four columns is your preferred tab width, so sorry if I guessed wrong.