### PR TITLE
Add a link to the BBC Programmes page for each programme

### DIFF
--- a/BBCSounds/BBCSoundsFeeder.pm
+++ b/BBCSounds/BBCSoundsFeeder.pm
@@ -21,6 +21,7 @@ use warnings;
 use strict;
 
 use URI::Escape;
+use URI;
 
 use Slim::Utils::Log;
 use Slim::Utils::Prefs;
@@ -31,6 +32,7 @@ use POSIX qw(strftime);
 use HTTP::Date;
 use Digest::MD5 qw(md5_hex);
 use Slim::Utils::Strings qw(string cstring);
+use XML::Simple qw(:strict);
 
 use Data::Dumper;
 
@@ -45,6 +47,7 @@ my $prefs = preferences('plugin.bbcsounds');
 my $cache = Slim::Utils::Cache->new();
 sub flushCache { $cache->cleanup(); }
 
+my $xml_simple = XML::Simple->new(KeepRoot => 1, KeyAttr => []);
 
 sub init {
 
@@ -1708,6 +1711,24 @@ sub soundsInfoIntegration {
 	my $items = [];
 	if (Plugins::BBCSounds::Utilities::isSoundsURL($url)) {
 		if (!(Plugins::BBCSounds::ProtocolHandler::isLive(undef,$url) || Plugins::BBCSounds::ProtocolHandler::isRewind(undef, $url))) {
+
+			my $programmes_url = URI->new('https://www.bbc.co.uk/');
+			$programmes_url->path_segments(
+				'programmes',
+				Plugins::BBCSounds::ProtocolHandler::getPid(undef, $url),
+			);
+			push @$items,
+			  {
+				name => $xml_simple->XMLout({
+					a => {
+						href => $programmes_url->as_string,
+						target => '_blank',
+						content => 'BBC Programmes page',
+					},
+				}),
+				type => 'textarea',
+			  };
+
 			push @$items,
 			  {
 				name => 'Tracklist',


### PR DESCRIPTION
This link appears on the web interface (where someone might want to click on it), but not on, e.g., a Squeezebox 3 (because these devices don’t support the `textarea` type.