### PR TITLE
Switch from JSON::XS::VersionOneAndTwo to JSON::XS

### DIFF
--- a/BBCSounds/ActivityManagement.pm
+++ b/BBCSounds/ActivityManagement.pm
@@ -25,7 +25,6 @@ use URI::Escape;
 use Slim::Utils::Log;
 use Slim::Networking::Async::HTTP;
 use Plugins::BBCSounds::SessionManagement;
-use JSON::XS::VersionOneAndTwo;
 
 my $log = logger('plugin.bbcsounds');
 

--- a/BBCSounds/BBCSoundsFeeder.pm
+++ b/BBCSounds/BBCSoundsFeeder.pm
@@ -27,7 +27,7 @@ use Slim::Utils::Log;
 use Slim::Utils::Prefs;
 use Slim::Networking::Async::HTTP;
 use Slim::Utils::Cache;
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS qw(decode_json);
 use POSIX qw(strftime);
 use HTTP::Date;
 use Digest::MD5 qw(md5_hex);

--- a/BBCSounds/PlayManager.pm
+++ b/BBCSounds/PlayManager.pm
@@ -21,7 +21,7 @@ use warnings;
 use strict;
 
 use URI::Escape;
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS qw(decode_json);
 
 use Slim::Utils::Log;
 

--- a/BBCSounds/RadioFavourites.pm
+++ b/BBCSounds/RadioFavourites.pm
@@ -18,7 +18,6 @@ package Plugins::BBCSounds::RadioFavourites;
 #  MA 02110-1301, USA.
 
 use Slim::Utils::Log;
-use JSON::XS::VersionOneAndTwo;
 use HTTP::Date;
 use Data::Dumper;
 

--- a/BBCSounds/SessionManagement.pm
+++ b/BBCSounds/SessionManagement.pm
@@ -29,7 +29,7 @@ use Slim::Utils::Prefs;
 use HTTP::Request::Common;
 use HTML::Entities;
 use HTTP::Cookies;
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS qw(decode_json);
 
 use Data::Dumper;
 


### PR DESCRIPTION
LMS no-longer uses `JSON::XS::VersionOneAndTwo` internally, and it’s simpler to use `JSON::XS` directly.